### PR TITLE
removed redundant features from mlua

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 
 [dependencies]
 # LUA
-mlua = { version = "0.8", features = ["lua54", "vendored", "async"] }
+mlua = { version = "0.8"}
 tealr = {version="0.9.0-alpha1", features=["mlua", "mlua_lua54", "mlua_vendored", "mlua_async"]} 
 
 # Threading


### PR DESCRIPTION
Tealr already passes the features to mlua. No need to set them again in mlua. 

Some features from mlua (actually, most of them) break its API in some way that tealr needs to know about. As a result, I _highly_ recommend to not enable any features in mlua directly but instead enable their equivalent in tealr. Doing this enables them in mlua (including in the mlua you depend directly on) and makes it harder to accidentally enable a feature only in mlua, which can cause compile errors.

Ideally, you don't depend on mlua directly and instead use the reexport under `tealr::mlu::mlua` to side step this entire problem but I also agree that depending on mlua directly is nicer if its used a lot and it isn't a problem for as long as you keep the feature thing in mind.