### PR TITLE
Support multipart

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ base64 = "0.13.1"
 # HTTP & URLS
 serde_json = "1.0.85"
 serde = { version = "1.0.144", features = ["derive"] }
-reqwest = "0.11.12"
+reqwest = { version = "0.11.12", features = ["multipart"] }
 url = "2.2.2"
 
 [profile.release]

--- a/src/cli/bar.rs
+++ b/src/cli/bar.rs
@@ -49,7 +49,7 @@ pub fn create_progress(bar: u64) {
 pub fn show_msg(message: &str, msglevel: MessageLevel) {
     let print_level = match msglevel {
         MessageLevel::Info => {
-            log::info!("{}",message);
+            log::info!("{}", message);
             format!("[{}]", Style::new().blue().apply_to("INFO"))
         }
         MessageLevel::Warn => {

--- a/src/cli/bar.rs
+++ b/src/cli/bar.rs
@@ -49,7 +49,7 @@ pub fn create_progress(bar: u64) {
 pub fn show_msg(message: &str, msglevel: MessageLevel) {
     let print_level = match msglevel {
         MessageLevel::Info => {
-            log::info!("{}", message);
+            log::info!("{}",message);
             format!("[{}]", Style::new().blue().apply_to("INFO"))
         }
         MessageLevel::Warn => {

--- a/src/cli/input/load_scripts.rs
+++ b/src/cli/input/load_scripts.rs
@@ -79,7 +79,7 @@ pub fn valid_scripts(
         }
         2 => {
             test_target_url = Some("https://example.com");
-        },
+        }
         3 => {}
         _ => {}
     }

--- a/src/cli/startup/scan.rs
+++ b/src/cli/startup/scan.rs
@@ -1,10 +1,9 @@
 use crate::cli::args::Opts;
 use crate::cli::input::{get_target_hosts, get_target_paths, get_target_urls};
 use crate::cli::logger::init_log;
-use crate::show_msg;
+use crate::{show_msg, MessageLevel};
 use crate::CliErrors;
 use crate::Lotus;
-use crate::MessageLevel;
 use crate::RequestOpts;
 use std::sync::{Arc, Mutex};
 use structopt::StructOpt;
@@ -92,7 +91,13 @@ pub fn args_scan() -> ScanArgs {
                 .iter()
                 .map(|url| url.to_string())
                 .collect::<Vec<String>>();
-            let paths = get_target_paths(urls_vec.clone());
+            let paths = match get_target_paths(urls_vec.clone()) {
+                Ok(paths) => paths,
+                Err(err) => {
+                    show_msg(&format!("Failed to get target paths: {}", err), MessageLevel::Error);
+                    vec![]
+                }
+            };
             let hosts = get_target_hosts(urls_vec.clone());
             (
                 urls_vec,

--- a/src/cli/startup/scan.rs
+++ b/src/cli/startup/scan.rs
@@ -1,10 +1,10 @@
 use crate::cli::args::Opts;
 use crate::cli::input::{get_target_hosts, get_target_paths, get_target_urls};
 use crate::cli::logger::init_log;
-use crate::{show_msg, MessageLevel};
 use crate::CliErrors;
 use crate::Lotus;
 use crate::RequestOpts;
+use crate::{show_msg, MessageLevel};
 use std::sync::{Arc, Mutex};
 use structopt::StructOpt;
 
@@ -94,7 +94,10 @@ pub fn args_scan() -> ScanArgs {
             let paths = match get_target_paths(urls_vec.clone()) {
                 Ok(paths) => paths,
                 Err(err) => {
-                    show_msg(&format!("Failed to get target paths: {}", err), MessageLevel::Error);
+                    show_msg(
+                        &format!("Failed to get target paths: {}", err),
+                        MessageLevel::Error,
+                    );
                     vec![]
                 }
             };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,7 @@ impl Lotus {
                 .await;
             },
             self.workers,
-        ).await;
+        )
+        .await;
     }
 }

--- a/src/lua/network/http.rs
+++ b/src/lua/network/http.rs
@@ -162,11 +162,11 @@ impl Sender {
                     log::debug!("{}", msg);
                 }
 
-                let mut resp_headers = HashMap::new();
-                resp.headers().iter().for_each(|(name, value)| {
-                    let value = String::from_utf8_lossy(value.as_bytes()).to_string();
-                    resp_headers.insert(name.to_string(), value);
-                });
+                let resp_headers = resp
+                    .headers()
+                    .iter()
+                    .map(|(name, value)| (name.to_string(), String::from_utf8_lossy(value.as_bytes()).to_string()))
+                    .collect::<HashMap<String, String>>();
 
                 let url = resp.url().to_string();
                 let status = resp.status().as_u16() as i32;

--- a/src/lua/network/http.rs
+++ b/src/lua/network/http.rs
@@ -53,7 +53,7 @@ impl Sender {
     fn create_form(&self, multipart: HashMap<String, MultiPart>) -> Form {
         let mut form = Form::new();
         for (key, part) in multipart {
-            let mut builder = Part::text(part.name);
+            let mut builder = Part::text(part.content);
             if let Some(filename) = part.filename {
                 builder = builder.file_name(filename);
             }

--- a/src/lua/network/http.rs
+++ b/src/lua/network/http.rs
@@ -13,10 +13,14 @@
 // and limitations under the License.
 
 use crate::BAR;
-use reqwest::{header::{HeaderMap, HeaderName, HeaderValue},multipart::{Form, Part}, redirect, Client, Method, Proxy};
+use reqwest::{
+    header::{HeaderMap, HeaderName, HeaderValue},
+    multipart::{Form, Part},
+    redirect, Client, Method, Proxy,
+};
 use std::collections::HashMap;
 mod http_lua_api;
-pub use http_lua_api::{Sender, MultiPart};
+pub use http_lua_api::{MultiPart, Sender};
 use lazy_static::lazy_static;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -81,11 +85,7 @@ impl Sender {
         redirects: u32,
         proxy: Option<String>,
     ) -> Result<reqwest::Client, reqwest::Error> {
-        let proxy = if proxy.is_none(){
-            &self.proxy
-        } else {
-            &proxy
-        };
+        let proxy = if proxy.is_none() { &self.proxy } else { &proxy };
         match proxy {
             Some(the_proxy) => Client::builder()
                 .timeout(Duration::from_secs(timeout))
@@ -147,7 +147,10 @@ impl Sender {
                     "The rate limit for requests has been reached. Sleeping for {} seconds...",
                     sleep_time
                 ));
-                log::debug!("The rate limit for requests has been reached. Sleeping for {} seconds...", sleep_time);
+                log::debug!(
+                    "The rate limit for requests has been reached. Sleeping for {} seconds...",
+                    sleep_time
+                );
                 std::thread::sleep(Duration::from_secs(sleep_time));
                 *req_sent = 1;
                 BAR.lock().unwrap().println("Continuing...");
@@ -195,7 +198,12 @@ impl Sender {
                 let resp_headers = resp
                     .headers()
                     .iter()
-                    .map(|(name, value)| (name.to_string(), String::from_utf8_lossy(value.as_bytes()).to_string()))
+                    .map(|(name, value)| {
+                        (
+                            name.to_string(),
+                            String::from_utf8_lossy(value.as_bytes()).to_string(),
+                        )
+                    })
                     .collect::<HashMap<String, String>>();
 
                 let url = resp.url().to_string();

--- a/src/lua/network/http.rs
+++ b/src/lua/network/http.rs
@@ -13,10 +13,10 @@
 // and limitations under the License.
 
 use crate::BAR;
-use reqwest::{header::HeaderMap, redirect, Client, Method, Proxy};
+use reqwest::{header::{HeaderMap, HeaderName, HeaderValue},multipart::{Form, Part}, redirect, Client, Method, Proxy};
 use std::collections::HashMap;
 mod http_lua_api;
-pub use http_lua_api::Sender;
+pub use http_lua_api::{Sender, MultiPart};
 use lazy_static::lazy_static;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -50,6 +50,30 @@ impl Sender {
         }
     }
 
+    fn create_form(&self, multipart: HashMap<String, MultiPart>) -> Form {
+        let mut form = Form::new();
+        for (key, part) in multipart {
+            let mut builder = Part::text(part.name);
+            if let Some(filename) = part.filename {
+                builder = builder.file_name(filename);
+            }
+            if let Some(content_type) = part.content_type {
+                builder = builder.mime_str(&content_type).unwrap();
+            }
+            if let Some(headers) = part.headers {
+                let mut current_headers = HeaderMap::new();
+                headers.iter().for_each(|(name, value)| {
+                    current_headers.insert(
+                        HeaderName::from_bytes(name.as_bytes()).unwrap(),
+                        HeaderValue::from_bytes(value.as_bytes()).unwrap(),
+                    );
+                });
+                builder = builder.headers(current_headers);
+            }
+            form = form.part(key, builder);
+        }
+        form
+    }
     fn build_client(
         &self,
         timeout: u64,
@@ -111,6 +135,7 @@ impl Sender {
         method: &str,
         url: String,
         body: Option<String>,
+        multipart: Option<HashMap<String, MultiPart>>,
         request_option: Sender,
     ) -> Result<HttpResponse, mlua::Error> {
         {
@@ -118,16 +143,14 @@ impl Sender {
             let mut req_sent = REQUESTS_SENT.lock().unwrap();
             if *req_sent >= req_limit {
                 let sleep_time = *SLEEP_TIME.lock().unwrap();
-                let bar = BAR.lock().unwrap();
-                let msg = format!(
+                BAR.lock().unwrap().println(&format!(
                     "The rate limit for requests has been reached. Sleeping for {} seconds...",
                     sleep_time
-                );
-                bar.println(&msg);
-                log::debug!("{}", msg);
+                ));
+                log::debug!("The rate limit for requests has been reached. Sleeping for {} seconds...", sleep_time);
                 std::thread::sleep(Duration::from_secs(sleep_time));
                 *req_sent = 1;
-                bar.println("Continuing...");
+                BAR.lock().unwrap().println("Continuing...");
                 log::debug!("Resetting req_sent value to 1");
             } else {
                 *req_sent += 1;
@@ -151,6 +174,13 @@ impl Sender {
                 request.body(body.unwrap())
             } else {
                 request
+            }
+        };
+        let request = {
+            if multipart.is_none() {
+                request
+            } else {
+                request.multipart(self.create_form(multipart.unwrap()))
             }
         };
         let response = match request.send().await {

--- a/src/lua/network/http/http_lua_api.rs
+++ b/src/lua/network/http/http_lua_api.rs
@@ -15,7 +15,7 @@ pub struct Sender {
 
 #[derive(TypeName, FromToLua)]
 pub struct MultiPart {
-    pub name: String,
+    pub content: String,
     pub filename: Option<String>,
     pub content_type: Option<String>,
     pub headers: Option<HashMap<String, String>>

--- a/src/lua/network/http/http_lua_api.rs
+++ b/src/lua/network/http/http_lua_api.rs
@@ -1,8 +1,8 @@
 use mlua::UserData;
-use tealr::{mlu::FromToLua, TypeName};
 use reqwest::header::HeaderMap;
 use reqwest::header::{HeaderName, HeaderValue};
 use std::collections::HashMap;
+use tealr::{mlu::FromToLua, TypeName};
 
 #[derive(Clone)]
 pub struct Sender {
@@ -18,7 +18,7 @@ pub struct MultiPart {
     pub content: String,
     pub filename: Option<String>,
     pub content_type: Option<String>,
-    pub headers: Option<HashMap<String, String>>
+    pub headers: Option<HashMap<String, String>>,
 }
 
 /// Adding OOP for http sender class
@@ -57,18 +57,28 @@ impl UserData for Sender {
             }
             let url = url.unwrap();
 
-            let multipart = request_option.get::<_, Option<HashMap<String, MultiPart>>>("multipart").unwrap_or_default();
-            let method = request_option.get::<_, Option<String>>("method")
-                .ok().flatten()
+            let multipart = request_option
+                .get::<_, Option<HashMap<String, MultiPart>>>("multipart")
+                .unwrap_or_default();
+            let method = request_option
+                .get::<_, Option<String>>("method")
+                .ok()
+                .flatten()
                 .unwrap_or_else(|| "GET".to_string());
-            let timeout = request_option.get::<_, Option<u64>>("timeout")
-                .ok().flatten()
+            let timeout = request_option
+                .get::<_, Option<u64>>("timeout")
+                .ok()
+                .flatten()
                 .unwrap_or_else(|| this.timeout);
-            let proxy = request_option.get::<_, Option<String>>("proxy")
-                .ok().flatten()
+            let proxy = request_option
+                .get::<_, Option<String>>("proxy")
+                .ok()
+                .flatten()
                 .or_else(|| this.proxy.clone());
-            let redirects = request_option.get::<_, Option<u32>>("redirect")
-                .ok().flatten()
+            let redirects = request_option
+                .get::<_, Option<u32>>("redirect")
+                .ok()
+                .flatten()
                 .unwrap_or_else(|| this.redirects);
             let headers = match request_option.get::<_, Option<HashMap<String, String>>>("headers")
             {
@@ -98,7 +108,9 @@ impl UserData for Sender {
                 redirects,
                 merge_headers: true,
             };
-            let resp = this.send(&method, url, body, multipart,current_request).await;
+            let resp = this
+                .send(&method, url, body, multipart, current_request)
+                .await;
             if resp.is_ok() {
                 Ok(resp.unwrap())
             } else {

--- a/src/lua/network/http/http_lua_api.rs
+++ b/src/lua/network/http/http_lua_api.rs
@@ -1,6 +1,7 @@
 use mlua::UserData;
 use reqwest::header::HeaderMap;
 use reqwest::header::{HeaderName, HeaderValue};
+use std::collections::HashMap;
 
 #[derive(Clone)]
 pub struct Sender {
@@ -8,6 +9,7 @@ pub struct Sender {
     pub proxy: Option<String>,
     pub timeout: u64,
     pub redirects: u32,
+    pub merge_headers: bool,
 }
 
 /// Adding OOP for http sender class
@@ -29,35 +31,68 @@ impl UserData for Sender {
             Ok(())
         });
 
+        methods.add_method_mut("merge_headers", |_, this, merge_headers: bool| {
+            this.merge_headers = merge_headers;
+            Ok(())
+        });
         methods.add_method_mut("set_redirects", |_, this, redirects: u32| {
             this.redirects = redirects;
             Ok(())
         });
-        methods.add_async_method(
-            "send",
-            |_, this, (method, url, req_body, req_headers): (String, String, mlua::Value, mlua::Value)| async move {
-                let mut all_headers = HeaderMap::new();
-                if let mlua::Value::Table(current_headers) = req_headers {
-                    current_headers.pairs::<String,String>().for_each(|currentheader| {
-                        all_headers.insert(HeaderName::from_bytes(currentheader.clone().unwrap().0.as_bytes()).unwrap(), HeaderValue::from_bytes(currentheader.unwrap().1.as_bytes()).unwrap());
+        methods.add_async_method("send", |_, this, request_option: mlua::Table| async move {
+            let url = request_option.get::<_, String>("url");
+            if url.is_err() {
+                return Err(mlua::Error::RuntimeError(
+                    "URL Parameter is required".to_string(),
+                ));
+            }
+            let url = url.unwrap();
+            let method = request_option.get::<_, Option<String>>("method")
+                .ok().flatten()
+                .unwrap_or_else(|| "GET".to_string());
+            let timeout = request_option.get::<_, Option<u64>>("timeout")
+                .ok().flatten()
+                .unwrap_or_else(|| this.timeout);
+            let proxy = request_option.get::<_, Option<String>>("proxy")
+                .ok().flatten()
+                .or_else(|| this.proxy.clone());
+            let redirects = request_option.get::<_, Option<u32>>("redirect")
+                .ok().flatten()
+                .unwrap_or_else(|| this.redirects);
+            let headers = match request_option.get::<_, Option<HashMap<String, String>>>("headers")
+            {
+                Ok(Some(headers)) => {
+                    let mut current_headers = HeaderMap::new();
+                    headers.iter().for_each(|(name, value)| {
+                        current_headers.insert(
+                            HeaderName::from_bytes(name.as_bytes()).unwrap(),
+                            HeaderValue::from_bytes(value.as_bytes()).unwrap(),
+                        );
                     });
-                }
-                let body: String = match req_body {
-                    mlua::Value::String(body) => {
-                        body.to_str().unwrap().to_string()
-                    },
-                    _ => {
-                        "".to_string()
+                    if this.merge_headers == true {
+                        current_headers.extend(this.headers.clone());
                     }
-                };
-
-                let resp = this.send(&method, url, body, all_headers).await;
-                if resp.is_ok(){
-                    Ok(resp.unwrap())
-                } else {
-                    Err(resp.unwrap_err())
+                    current_headers
                 }
-            },
-        );
+                _ => this.headers.clone(),
+            };
+            let body = match request_option.get::<_, Option<String>>("body") {
+                Ok(Some(body)) if !body.is_empty() => Some(body),
+                _ => None,
+            };
+            let current_request = Sender {
+                timeout,
+                proxy,
+                headers,
+                redirects,
+                merge_headers: true,
+            };
+            let resp = this.send(&method, url, body, current_request).await;
+            if resp.is_ok() {
+                Ok(resp.unwrap())
+            } else {
+                Err(resp.unwrap_err())
+            }
+        });
     }
 }

--- a/src/lua/output/general.rs
+++ b/src/lua/output/general.rs
@@ -7,7 +7,7 @@ pub struct GeneralReport {
     pub description: Option<String>,
     pub target: Option<String>,
     pub risk: Option<String>,
-    pub matchers: Vec<serde_json::Value>
+    pub matchers: Vec<serde_json::Value>,
 }
 
 impl UserData for GeneralReport {
@@ -29,7 +29,7 @@ impl UserData for GeneralReport {
             this.description = Some(description);
             Ok(())
         });
-        methods.add_method_mut("setMatchers", |_, this, matching_data: mlua::Value|{
+        methods.add_method_mut("setMatchers", |_, this, matching_data: mlua::Value| {
             let matching_data_json = serde_json::to_value(&matching_data).unwrap();
             this.matchers.push(matching_data_json);
             Ok(())
@@ -44,7 +44,7 @@ impl GeneralReport {
             target: None,
             description: None,
             risk: None,
-            matchers: vec![]
+            matchers: vec![],
         }
     }
 }

--- a/src/lua/output/mod.rs
+++ b/src/lua/output/mod.rs
@@ -1,3 +1,3 @@
 pub mod cve;
-pub mod vuln;
 pub mod general;
+pub mod vuln;

--- a/src/lua/output/vuln.rs
+++ b/src/lua/output/vuln.rs
@@ -12,10 +12,7 @@
 // either express or implied. See the License for the specific language governing permissions
 // and limitations under the License.
 
-use crate::lua::output::{
-    cve::CveReport,
-    general::GeneralReport
-};
+use crate::lua::output::{cve::CveReport, general::GeneralReport};
 use mlua::UserData;
 use serde::{Deserialize, Serialize};
 
@@ -24,7 +21,7 @@ use serde::{Deserialize, Serialize};
 pub enum LotusReport {
     CVE(CveReport),
     VULN(OutReport),
-    GENERAL(GeneralReport)
+    GENERAL(GeneralReport),
 }
 
 #[derive(Clone, Deserialize, Serialize)]

--- a/src/lua/parsing/url.rs
+++ b/src/lua/parsing/url.rs
@@ -22,11 +22,7 @@ pub struct HttpMessage {
 }
 
 impl HttpMessage {
-    pub fn change_urlquery(
-        &self,
-        payload: &str,
-        remove_content: bool,
-    ) -> HashMap<String, String> {
+    pub fn change_urlquery(&self, payload: &str, remove_content: bool) -> HashMap<String, String> {
         let mut scan_params = HashMap::with_capacity(16);
         let mut result = HashMap::with_capacity(16);
 

--- a/src/lua/run.rs
+++ b/src/lua/run.rs
@@ -1,3 +1,6 @@
+use crate::lua::runtime::{
+    encode_ext::EncodeEXT, http_ext::HTTPEXT, payloads_ext::PayloadsEXT, utils_ext::UtilsEXT,
+};
 use crate::{
     cli::bar::BAR,
     lua::{
@@ -7,7 +10,6 @@ use crate::{
     },
     RequestOpts, ScanTypes,
 };
-use crate::lua::runtime::{encode_ext::EncodeEXT, http_ext::HTTPEXT, payloads_ext::PayloadsEXT, utils_ext::UtilsEXT};
 use mlua::Lua;
 use std::fs::OpenOptions;
 use std::io::Write;
@@ -77,7 +79,6 @@ impl LuaLoader {
     pub async fn run_scan<'a>(&self, lua_opts: LuaOptions<'_>) -> Result<(), mlua::Error> {
         let lua = Lua::new();
 
-        // set lua globals
         lua.globals()
             .set("SCRIPT_PATH", lua_opts.script_dir)
             .unwrap();
@@ -120,7 +121,10 @@ impl LuaLoader {
         }
 
         log::debug!("Calling the main function: {}", lua_opts.script_dir);
-        let run_scan = main_func.unwrap().call_async::<_, mlua::Value>(mlua::Value::Nil).await;
+        let run_scan = main_func
+            .unwrap()
+            .call_async::<_, mlua::Value>(mlua::Value::Nil)
+            .await;
         BAR.lock().unwrap().inc(1);
 
         if let Err(e) = run_scan {
@@ -135,15 +139,13 @@ impl LuaLoader {
                 let report_count = script_report.reports.len();
                 let log_message = format!(
                     "The script in directory [{}] generated {} report(s):\n\n{}\n\n",
-                    lua_opts.script_dir,
-                    report_count,
-                    results
+                    lua_opts.script_dir, report_count, results
                 );
                 log::debug!("{}", log_message);
                 self.write_report(&results);
             }
         }
 
-    Ok(())
+        Ok(())
     }
 }

--- a/src/lua/run.rs
+++ b/src/lua/run.rs
@@ -100,6 +100,7 @@ impl LuaLoader {
         };
 
         // execute script code
+        log::debug!("Executing Code: {}", lua_opts.script_dir);
         let run_code = lua.load(lua_opts.script_code).exec_async().await;
         if let Err(e) = run_code {
             let bar = BAR.lock().unwrap();
@@ -118,6 +119,7 @@ impl LuaLoader {
             return Ok(());
         }
 
+        log::debug!("Calling the main function: {}", lua_opts.script_dir);
         let run_scan = main_func.unwrap().call_async::<_, mlua::Value>(mlua::Value::Nil).await;
         BAR.lock().unwrap().inc(1);
 

--- a/src/lua/runtime/http_ext.rs
+++ b/src/lua/runtime/http_ext.rs
@@ -2,8 +2,8 @@ use crate::{
     lua::{
         output::{
             cve::CveReport,
+            general::GeneralReport,
             vuln::{AllReports, OutReport},
-            general::GeneralReport
         },
         parsing::url::HttpMessage,
     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,10 @@ use structopt::StructOpt;
 async fn main() -> Result<(), std::io::Error> {
     match Opts::from_args() {
         Opts::SCAN { .. } => run_scan().await,
-        Opts::NEW { scan_type, file_name } => {
+        Opts::NEW {
+            scan_type,
+            file_name,
+        } => {
             new_args(scan_type, file_name);
             std::process::exit(0);
         }
@@ -40,9 +43,18 @@ async fn main() -> Result<(), std::io::Error> {
 async fn run_scan() -> Result<(), std::io::Error> {
     let opts = args_scan();
     let fuzz_workers = opts.fuzz_workers;
-    show_msg(&format!("URLS: {}", opts.target_data.urls.len()), MessageLevel::Info);
-    show_msg(&format!("HOSTS: {}", opts.target_data.hosts.len()), MessageLevel::Info);
-    show_msg(&format!("PATHS: {}", opts.target_data.paths.len()), MessageLevel::Info);
+    show_msg(
+        &format!("URLS: {}", opts.target_data.urls.len()),
+        MessageLevel::Info,
+    );
+    show_msg(
+        &format!("HOSTS: {}", opts.target_data.hosts.len()),
+        MessageLevel::Info,
+    );
+    show_msg(
+        &format!("PATHS: {}", opts.target_data.paths.len()),
+        MessageLevel::Info,
+    );
     // Open two threads for URL/HOST scanning
     create_progress(opts.target_data.urls.len() as u64);
     {

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -1,14 +1,20 @@
-use reqwest::header::{HeaderMap, HeaderValue};
 use lotus::lua::network::http::Sender;
+use reqwest::header::{HeaderMap, HeaderValue};
 
 #[tokio::test]
 async fn test_send() {
-
     // Create test sender
     let sender = Sender::init(HeaderMap::new(), None, 10, 3);
 
     // Send test request
-    let resp = sender.send("GET", "https://httpbin.org/get".to_string(), "".to_string(), HeaderMap::new()).await;
+    let resp = sender
+        .send(
+            "GET",
+            "https://httpbin.org/get".to_string(),
+            None,
+            sender.clone()
+        )
+        .await;
     assert!(resp.is_ok());
 
     // Check response body
@@ -22,10 +28,18 @@ fn test_init() {
     let headers = HeaderMap::new();
 
     // Create test sender
-    let sender = Sender::init(headers, Some("http://proxy.example.com:8080".to_string()), 10, 3);
+    let sender = Sender::init(
+        headers,
+        Some("http://proxy.example.com:8080".to_string()),
+        10,
+        3,
+    );
 
     // Check sender properties
-    assert_eq!(sender.proxy, Some("http://proxy.example.com:8080".to_string()));
+    assert_eq!(
+        sender.proxy,
+        Some("http://proxy.example.com:8080".to_string())
+    );
     assert_eq!(sender.timeout, 10);
     assert_eq!(sender.redirects, 3);
 }
@@ -37,9 +51,17 @@ fn test_build_client() {
     headers.insert("Content-Type", HeaderValue::from_static("application/json"));
 
     // Create test sender
-    let sender = Sender::init(headers.clone(), Some("http://proxy.example.com:8080".to_string()), 10, 3);
+    let sender = Sender::init(
+        headers.clone(),
+        Some("http://proxy.example.com:8080".to_string()),
+        10,
+        3,
+    );
 
-    assert_eq!(sender.proxy.unwrap().as_str(), "http://proxy.example.com:8080");
+    assert_eq!(
+        sender.proxy.unwrap().as_str(),
+        "http://proxy.example.com:8080"
+    );
 
     // Test no-proxy client builder
     let sender = Sender::init(headers.clone(), None, 10, 3);

--- a/tests/url.rs
+++ b/tests/url.rs
@@ -9,7 +9,12 @@ fn test_change_urlquery() {
     let payload = "new_value";
     let expected_result = [("key1", "new_value"), ("key2", "new_value")]
         .iter()
-        .map(|(k, v)| (k.to_string(), format!("https://example.com/path?{}={}", k, v)))
+        .map(|(k, v)| {
+            (
+                k.to_string(),
+                format!("https://example.com/path?{}={}", k, v),
+            )
+        })
         .collect::<HashMap<String, String>>();
 
     let result = http_msg.change_urlquery(payload, true);


### PR DESCRIPTION
for #93 

### Changes
- Calling http:send function with table to give full control of the connection option 
- Supporting multipart parameters
- adding merge_headers option to disable/enable the default headers
```lua
    multipart = {} -- {param_name: content}
    param_content = {}
    param_content["content"] = "khaled" // parameter body [required]
    param_content["content_type"] = "text/html" // parameter content-type [optional]
    param_content["filename"] = "name.html" // filename [optional]
    multipart["name"] = param_content
    http:send{method="GET",url="http://google.com",multipart = multipart,timeout=10, headers=headers} end)

```