### PR TITLE
Global vars

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -3,6 +3,7 @@ use reqwest::header::HeaderMap;
 use reqwest::header::{HeaderName, HeaderValue};
 use std::collections::HashMap;
 use std::path::PathBuf;
+use serde_json::Value;
 use structopt::StructOpt;
 
 fn parse_headers(raw_headers: &str) -> Result<HeaderMap, serde_json::Error> {
@@ -30,6 +31,11 @@ fn parse_headers(raw_headers: &str) -> Result<HeaderMap, serde_json::Error> {
             );
         });
     Ok(user_headers)
+}
+
+fn get_env_vars(env_vars_json: &str) -> Result<Value, serde_json::Error> {
+    let parsed_vars = serde_json::from_str(env_vars_json)?;
+    Ok(parsed_vars)
 }
 
 fn get_script_type(script_type: &str) -> Result<ScriptType, CliErrors> {
@@ -165,5 +171,7 @@ pub enum Opts {
             help = "Exit after X number of script errors"
         )]
         exit_after: i32,
+        #[structopt(long = "env-vars",parse(try_from_str = get_env_vars),default_value="{}",help = "Set Global Vars for scripts")]
+        env_vars: Value
     },
 }

--- a/src/cli/startup/scan.rs
+++ b/src/cli/startup/scan.rs
@@ -57,6 +57,7 @@ pub fn args_scan() -> ScanArgs {
             fuzz_workers,
             verbose,
             is_request,
+            env_vars
         } => {
             // setup logger
             init_log(log).unwrap();
@@ -72,6 +73,7 @@ pub fn args_scan() -> ScanArgs {
                 workers,
                 script_workers: scripts_workers,
                 stop_after: Arc::new(Mutex::new(1)),
+                env_vars
             };
             let urls = get_target_urls(urls);
             if urls.is_err() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@ pub struct Lotus {
     pub script_workers: usize,
     /// Stop After X of errors
     pub stop_after: Arc<Mutex<i32>>,
+    pub env_vars: serde_json::Value
 }
 
 impl Lotus {
@@ -112,6 +113,7 @@ impl Lotus {
                             fuzz_workers,
                             script_code: &script_code,
                             script_dir: &script_name,
+                            env_vars: self.env_vars.clone()
                         };
                         if *self.stop_after.lock().unwrap() == exit_after {
                             log::debug!("Ignoring scripts");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ impl Lotus {
         }
         let lotus_obj = Arc::new(LuaLoader::new(
             request_option.clone(),
-            self.output.as_ref().unwrap().to_str().unwrap().to_string(),
+            self.output.clone(),
         ));
         let scan_type = Arc::new(scan_type);
         iter_futures(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,10 +90,6 @@ impl Lotus {
             ScanTypes::PATHS => valid_scripts(get_scripts(self.script_path.clone()), 3),
             _ => valid_scripts(get_scripts(self.script_path.clone()), 2),
         };
-        if self.output.is_none() {
-            show_msg("Output argument is missing", MessageLevel::Error);
-            std::process::exit(1);
-        }
         let lotus_obj = Arc::new(LuaLoader::new(
             request_option.clone(),
             self.output.clone(),

--- a/src/lua/loader.rs
+++ b/src/lua/loader.rs
@@ -28,6 +28,7 @@ pub struct LuaOptions<'a> {
     pub fuzz_workers: usize,
     pub script_code: &'a str,
     pub script_dir: &'a str,
+    pub env_vars: serde_json::Value
 }
 
 /// check if the regex pattern is matching with this string or not without get the matched parts

--- a/src/lua/run.rs
+++ b/src/lua/run.rs
@@ -13,10 +13,11 @@ use crate::{
 use mlua::Lua;
 use std::fs::OpenOptions;
 use std::io::Write;
+use std::path::PathBuf;
 
 #[derive(Clone)]
 pub struct LuaLoader {
-    output_dir: String,
+    output_dir: Option<PathBuf>,
     request: RequestOpts,
 }
 
@@ -24,7 +25,7 @@ pub struct LuaLoader {
 /// * `request` - Request Options
 /// * `output_dir` - output file
 impl LuaLoader {
-    pub fn new(request: RequestOpts, output_dir: String) -> LuaLoader {
+    pub fn new(request: RequestOpts, output_dir: Option<PathBuf>) -> LuaLoader {
         Self {
             output_dir,
             request,
@@ -67,7 +68,7 @@ impl LuaLoader {
             .write(true)
             .append(true)
             .create(true)
-            .open(&self.output_dir)
+            .open(&self.output_dir.as_ref().unwrap())
             .expect("Could not open file")
             .write_all(format!("{}\n", results).as_str().as_bytes())
             .expect("Could not write to file");
@@ -142,7 +143,9 @@ impl LuaLoader {
                     lua_opts.script_dir, report_count, results
                 );
                 log::debug!("{}", log_message);
-                self.write_report(&results);
+                if self.output_dir.is_some() {
+                    self.write_report(&results);
+                }
             }
         }
 

--- a/src/lua/run.rs
+++ b/src/lua/run.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     RequestOpts, ScanTypes,
 };
-use mlua::Lua;
+use mlua::{Lua, LuaSerdeExt};
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::PathBuf;
@@ -79,7 +79,10 @@ impl LuaLoader {
     /// * `target_type` - the input type if its HOST or URL
     pub async fn run_scan<'a>(&self, lua_opts: LuaOptions<'_>) -> Result<(), mlua::Error> {
         let lua = Lua::new();
+        let env_vars: mlua::Value = lua.to_value(&lua_opts.env_vars).unwrap();
 
+        lua.globals()
+            .set("ENV", env_vars).unwrap();
         lua.globals()
             .set("SCRIPT_PATH", lua_opts.script_dir)
             .unwrap();

--- a/src/lua/runtime/http_ext.rs
+++ b/src/lua/runtime/http_ext.rs
@@ -1,14 +1,12 @@
 use crate::{
     lua::{
         output::report::AllReports,
-        parsing::url::HttpMessage,
+        parsing::{url::HttpMessage, files::filename_to_string},
     },
     CliErrors, LuaRunTime,
 };
 use log::{debug, error, info, warn};
 use mlua::ExternalError;
-use std::fs::File;
-use std::io::prelude::*;
 use std::path::Path;
 use std::time::Duration;
 use std::collections::HashMap;
@@ -111,9 +109,7 @@ impl HTTPEXT for LuaRunTime<'_> {
                 self.lua
                     .create_function(|_ctx, file_path: String| {
                         if Path::new(&file_path).exists() {
-                            let mut file = File::open(&file_path)?;
-                            let mut file_content = String::new();
-                            file.read_to_string(&mut file_content)?;
+                            let file_content = filename_to_string(&file_path)?;
                             Ok(file_content)
                         } else {
                             Err(CliErrors::ReadingError.to_lua_err())


### PR DESCRIPTION
#90
### Change Log
- Add ENV-VARS Option
- Making output option not required


```bash
$ echo "http://google.com/?d=1" | lotus scan test.lua   --env-vars='{"NAME":"KHALED"}'
```

```lua
println(ENV["NAME"])
-- KHALED
```