### PR TITLE
Add support for regular expressions in ResponseMatcher struct in text.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ thiserror = "1.0"
 
 # REGEX AND MATCHES
 fancy-regex = "0.10.0"
+regex = "1.7.3"
 scraper = "0.13.0"
 
 # Dirs


### PR DESCRIPTION
for #99 
This commit adds support for regular expressions to the ResponseMatcher struct in text.rs. The new match_and_body and match_once_body methods now accept an optional boolean parameter is_regex to enable or disable regex matching. The methods use the regex crate to compile and match regular expressions against the body string parameter.

This change improves the versatility of the ResponseMatcher struct and allows for more precise matching of text responses in Lua scripts.