### PR TITLE
Add regex option to ResponseMatcher

### DIFF
--- a/src/cli/bar.rs
+++ b/src/cli/bar.rs
@@ -41,7 +41,10 @@ pub fn create_progress(bar: u64) {
             .progress_chars("#>-")
             .tick_strings(&["🌕", "🌖", "🌗", "🌘", "🌑", "🌒", "🌓", "🌔"])
             //.tick_chars("⣾⣽⣻⢿⡿⣟⣯⣷".to_string().as_str())
-            .template("{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos:>7}/{len:7} {msg}").unwrap()
+            .template(
+                "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos:>7}/{len:7} {msg}",
+            )
+            .unwrap(),
     );
 }
 

--- a/src/lua/parsing/text.rs
+++ b/src/lua/parsing/text.rs
@@ -13,8 +13,8 @@
 // and limitations under the License.
 
 use mlua::UserData;
-use tealr::TypeName;
 use regex::RegexBuilder;
+use tealr::TypeName;
 
 #[derive(TypeName, Clone, Debug)]
 pub struct ResponseMatcher {
@@ -23,7 +23,7 @@ pub struct ResponseMatcher {
     pub ignore_whitespace: bool,
     pub unicode: bool,
     pub octal: bool,
-    pub dot_matches_new_line: bool
+    pub dot_matches_new_line: bool,
 }
 
 impl ResponseMatcher {
@@ -37,7 +37,8 @@ impl ResponseMatcher {
                     .unicode(self.unicode)
                     .octal(self.octal)
                     .dot_matches_new_line(self.dot_matches_new_line)
-                    .build() {
+                    .build()
+                {
                     if re_pattern.is_match(body) {
                         counter += 1;
                     }
@@ -49,7 +50,12 @@ impl ResponseMatcher {
         counter == text.len()
     }
 
-    pub fn match_once_body(&self, body: String, text: Vec<String>, is_regex: Option<bool>) -> Vec<String> {
+    pub fn match_once_body(
+        &self,
+        body: String,
+        text: Vec<String>,
+        is_regex: Option<bool>,
+    ) -> Vec<String> {
         let mut matched_data = Vec::new();
         for pattern in text {
             if is_regex.unwrap_or(false) {
@@ -59,7 +65,8 @@ impl ResponseMatcher {
                     .unicode(self.unicode)
                     .octal(self.octal)
                     .dot_matches_new_line(self.dot_matches_new_line)
-                    .build() {
+                    .build()
+                {
                     if re.is_match(&body) {
                         matched_data.push(pattern);
                     }
@@ -77,24 +84,30 @@ impl UserData for ResponseMatcher {
         methods.add_method(
             "match_body",
             |_, this, (response, text_list, is_regex): (String, Vec<String>, Option<bool>)| {
-                Ok(this.match_and_body(&response, text_list,is_regex))
+                Ok(this.match_and_body(&response, text_list, is_regex))
             },
         );
         methods.add_method(
             "match_body_once",
             |_, this, (response, text_list, is_regex): (String, Vec<String>, Option<bool>)| {
-                let is_match = this.match_once_body(response, text_list,is_regex);
+                let is_match = this.match_once_body(response, text_list, is_regex);
                 Ok(is_match)
             },
         );
         methods.add_method_mut("options", |_, this, opts: mlua::Table| {
             let response_matcher = ResponseMatcher {
                 multi_line: opts.get::<_, bool>("multi_line").unwrap_or(this.multi_line),
-                case_insensitive: opts.get::<_, bool>("case_insensitive").unwrap_or(this.case_insensitive),
-                ignore_whitespace: opts.get::<_, bool>("ignore_whitespace").unwrap_or(this.ignore_whitespace),
+                case_insensitive: opts
+                    .get::<_, bool>("case_insensitive")
+                    .unwrap_or(this.case_insensitive),
+                ignore_whitespace: opts
+                    .get::<_, bool>("ignore_whitespace")
+                    .unwrap_or(this.ignore_whitespace),
                 unicode: opts.get::<_, bool>("unicode").unwrap_or(this.unicode),
                 octal: opts.get::<_, bool>("octal").unwrap_or(this.octal),
-                dot_matches_new_line: opts.get::<_, bool>("dot_matches_new_line").unwrap_or(this.dot_matches_new_line),
+                dot_matches_new_line: opts
+                    .get::<_, bool>("dot_matches_new_line")
+                    .unwrap_or(this.dot_matches_new_line),
             };
 
             *this = response_matcher;

--- a/src/lua/runtime/utils_ext.rs
+++ b/src/lua/runtime/utils_ext.rs
@@ -88,14 +88,17 @@ impl UtilsEXT for LuaRunTime<'_> {
 
         self.lua
             .globals()
-            .set("ResponseMatcher", ResponseMatcher {
-                ignore_whitespace: false,
-                case_insensitive: false,
-                multi_line: false,
-                octal: true,
-                unicode: true,
-                dot_matches_new_line: false
-            })
+            .set(
+                "ResponseMatcher",
+                ResponseMatcher {
+                    ignore_whitespace: false,
+                    case_insensitive: false,
+                    multi_line: false,
+                    octal: true,
+                    unicode: true,
+                    dot_matches_new_line: false,
+                },
+            )
             .unwrap();
 
         self.lua

--- a/src/lua/runtime/utils_ext.rs
+++ b/src/lua/runtime/utils_ext.rs
@@ -88,7 +88,14 @@ impl UtilsEXT for LuaRunTime<'_> {
 
         self.lua
             .globals()
-            .set("ResponseMatcher", ResponseMatcher {})
+            .set("ResponseMatcher", ResponseMatcher {
+                ignore_whitespace: false,
+                case_insensitive: false,
+                multi_line: false,
+                octal: true,
+                unicode: true,
+                dot_matches_new_line: false
+            })
             .unwrap();
 
         self.lua


### PR DESCRIPTION
This PR adds the ability to use regular expressions when matching a response body in the ResponseMatcher struct. The new ResponseMatcher options are multi_line, case_insensitive, ignore_whitespace, unicode, octal, and dot_matches_new_line. These options can be passed in using a Lua table when creating a ResponseMatcher object, or can be set using the options method.

The commit also includes modifications to the ResponseMatcher implementation to enable regex matching. A new is_regex parameter is added to the match_and_body method to indicate whether a regex pattern should be used for matching. The method now builds a Regex object using the provided regex pattern and the new ResponseMatcher options, and then checks whether the pattern matches the provided response body.

Finally, this commit includes updates to the UtilsEXT implementation to set default options for the ResponseMatcher object when creating it in the Lua runtime.
