### PR TITLE
Rename Response Matcher

### DIFF
--- a/src/lua/runtime/utils_ext.rs
+++ b/src/lua/runtime/utils_ext.rs
@@ -89,7 +89,7 @@ impl UtilsEXT for LuaRunTime<'_> {
         self.lua
             .globals()
             .set(
-                "ResponseMatcher",
+                "Matcher",
                 ResponseMatcher {
                     ignore_whitespace: false,
                     case_insensitive: false,


### PR DESCRIPTION
you can use `Matcher` instead of `ResponseMatcher`