### PR TITLE
Impl iter_scan

### DIFF
--- a/src/cli/args/scan.rs
+++ b/src/cli/args/scan.rs
@@ -16,7 +16,7 @@ use structopt::StructOpt;
 fn parse_scan_content_type(input_content: &str) -> Result<(), CliErrors> {
     let mut is_error = false;
     // Removing The Default Option
-    block_on(async { SCAN_CONTENT_TYPE.lock().await.clear()});
+    block_on(async { SCAN_CONTENT_TYPE.lock().await.clear() });
 
     input_content.split(",").for_each(|the_scan_type| {
         if the_scan_type == "url" {
@@ -24,7 +24,12 @@ fn parse_scan_content_type(input_content: &str) -> Result<(), CliErrors> {
         } else if the_scan_type == "body" {
             block_on(async { SCAN_CONTENT_TYPE.lock().await.push(InjectionLocation::Body) });
         } else if the_scan_type == "json" {
-            block_on(async { SCAN_CONTENT_TYPE.lock().await.push(InjectionLocation::BodyJson) });
+            block_on(async {
+                SCAN_CONTENT_TYPE
+                    .lock()
+                    .await
+                    .push(InjectionLocation::BodyJson)
+            });
         } else if the_scan_type == "headers" {
             block_on(async {
                 SCAN_CONTENT_TYPE


### PR DESCRIPTION
You can run two iters for every thread:)
```lua
SCAN_TYPE = 0
COUNTER = 0
PAYLOADS = {1, 2, 3, 4, 5, 5, 7, 7}

function tester(param_type, payloads)
    local reqs = full_req:set(param_type, payloads)
    for _, req in pairs(reqs) do
        local resp = req:send(req,http)
        println(resp.status)
    end
end

function main()
    http:merge_headers(true)
    -- LuaThreader:run_iters(one_iter,two_iter)
    LuaThreader:iter_scan({full_req:json(), full_req:url()}, PAYLOADS, tester, 10)
end

```